### PR TITLE
replacing is domain name

### DIFF
--- a/common/atomic/typed.go
+++ b/common/atomic/typed.go
@@ -42,5 +42,9 @@ func (t *TypedValue[T]) Swap(new T) T {
 }
 
 func (t *TypedValue[T]) CompareAndSwap(old, new T) bool {
-	return t.value.CompareAndSwap(typedValue[T]{old}, typedValue[T]{new})
+	return t.value.CompareAndSwap(typedValue[T]{old}, typedValue[T]{new}) ||
+		// In the edge-case where [atomic.Value.Store] is uninitialized
+		// and trying to compare with the zero value of T,
+		// then compare-and-swap with the nil any value.
+		(any(old) == any(common.DefaultValue[T]()) && t.value.CompareAndSwap(any(nil), typedValue[T]{new}))
 }

--- a/common/buf/alloc.go
+++ b/common/buf/alloc.go
@@ -89,7 +89,7 @@ func (alloc *defaultAllocator) Get(size int) []byte {
 // which the cap must be exactly 2^n
 func (alloc *defaultAllocator) Put(buf []byte) error {
 	bits := msb(cap(buf))
-	if cap(buf) == 0 || cap(buf) > 65536 || cap(buf) != 1<<bits {
+	if cap(buf) == 0 || cap(buf) < 64 || cap(buf) > 65536 || cap(buf) != 1<<bits {
 		return errors.New("allocator Put() incorrect buffer size")
 	}
 	bits -= 6

--- a/common/buf/alloc.go
+++ b/common/buf/alloc.go
@@ -89,7 +89,7 @@ func (alloc *defaultAllocator) Get(size int) []byte {
 // which the cap must be exactly 2^n
 func (alloc *defaultAllocator) Put(buf []byte) error {
 	bits := msb(cap(buf))
-	if cap(buf) == 0 || cap(buf) < 64 || cap(buf) > 65536 || cap(buf) != 1<<bits {
+	if cap(buf) < 64 || cap(buf) > 65536 || cap(buf) != 1<<bits {
 		return errors.New("allocator Put() incorrect buffer size")
 	}
 	bits -= 6

--- a/common/byteformats/formats.go
+++ b/common/byteformats/formats.go
@@ -1,0 +1,42 @@
+package byteformats
+
+import (
+	"fmt"
+	"math"
+)
+
+var (
+	unitNames  = []string{"B", "kB", "MB", "GB", "TB", "PB", "EB"}
+	iUnitNames = []string{"B", "KiB", "MiB", "GiB", "TiB", "PiB", "EiB"}
+)
+
+func formatBytes(s uint64, base float64, sizes []string) string {
+	if s < 10 {
+		return fmt.Sprintf("%d B", s)
+	}
+	e := math.Floor(logn(float64(s), base))
+	suffix := sizes[int(e)]
+	val := math.Floor(float64(s)/math.Pow(base, e)*10+0.5) / 10
+	f := "%.0f %s"
+	if val < 10 {
+		f = "%.1f %s"
+	}
+
+	return fmt.Sprintf(f, val, suffix)
+}
+
+func logn(n, b float64) float64 {
+	return math.Log(n) / math.Log(b)
+}
+
+func FormatBytes(s uint64) string {
+	return formatBytes(s, 1000, unitNames)
+}
+
+func FormatMemoryBytes(s uint64) string {
+	return formatBytes(s, 1024, unitNames)
+}
+
+func FormatIBytes(s uint64) string {
+	return formatBytes(s, 1024, iUnitNames)
+}

--- a/common/byteformats/json.go
+++ b/common/byteformats/json.go
@@ -93,13 +93,6 @@ type rawBytes struct {
 	unitValue uint64
 }
 
-func (b *rawBytes) Value() uint64 {
-	if b == nil {
-		return 0
-	}
-	return b.value
-}
-
 func (b rawBytes) MarshalJSON() ([]byte, error) {
 	if b.unit == "" {
 		return json.Marshal(b.value)
@@ -156,12 +149,26 @@ type Bytes struct {
 	rawBytes
 }
 
+func (b *Bytes) Value() uint64 {
+	if b == nil {
+		return 0
+	}
+	return b.value
+}
+
 func (b *Bytes) UnmarshalJSON(bytes []byte) error {
 	return parseUnit(&b.rawBytes, unitValueTable, false, bytes)
 }
 
 type MemoryBytes struct {
 	rawBytes
+}
+
+func (b *MemoryBytes) Value() uint64 {
+	if b == nil {
+		return 0
+	}
+	return b.value
 }
 
 func (m *MemoryBytes) UnmarshalJSON(bytes []byte) error {
@@ -172,12 +179,26 @@ type NetworkBytes struct {
 	rawBytes
 }
 
+func (n *NetworkBytes) Value() uint64 {
+	if n == nil {
+		return 0
+	}
+	return n.value
+}
+
 func (n *NetworkBytes) UnmarshalJSON(bytes []byte) error {
 	return parseUnit(&n.rawBytes, networkUnitValueTable, true, bytes)
 }
 
 type NetworkBytesCompat struct {
 	rawBytes
+}
+
+func (n *NetworkBytesCompat) Value() uint64 {
+	if n == nil {
+		return 0
+	}
+	return n.value
 }
 
 func (n *NetworkBytesCompat) UnmarshalJSON(bytes []byte) error {

--- a/common/byteformats/json.go
+++ b/common/byteformats/json.go
@@ -1,0 +1,192 @@
+package byteformats
+
+import (
+	"strconv"
+	"strings"
+
+	E "github.com/sagernet/sing/common/exceptions"
+	"github.com/sagernet/sing/common/json"
+)
+
+const (
+	Byte = 1 << (iota * 10)
+	KiByte
+	MiByte
+	GiByte
+	TiByte
+	PiByte
+	EiByte
+)
+
+const (
+	KByte = Byte * 1000
+	MByte = KByte * 1000
+	GByte = MByte * 1000
+	TByte = GByte * 1000
+	PByte = TByte * 1000
+	EByte = PByte * 1000
+)
+
+var unitValueTable = map[string]uint64{
+	"b":   Byte,
+	"k":   KByte,
+	"kb":  KByte,
+	"ki":  KiByte,
+	"kib": KiByte,
+	"m":   MByte,
+	"mb":  MByte,
+	"mi":  MiByte,
+	"mib": MiByte,
+	"g":   GByte,
+	"gb":  GByte,
+	"gi":  GiByte,
+	"gib": GiByte,
+	"t":   TByte,
+	"tb":  TByte,
+	"ti":  TiByte,
+	"tib": TiByte,
+	"p":   PByte,
+	"pb":  PByte,
+	"pi":  PiByte,
+	"pib": PiByte,
+	"e":   EByte,
+	"eb":  EByte,
+	"ei":  EiByte,
+	"eib": EiByte,
+}
+
+var memoryUnitValueTable = map[string]uint64{
+	"b":  Byte,
+	"k":  KiByte,
+	"kb": KiByte,
+	"m":  MiByte,
+	"mb": MiByte,
+	"g":  GiByte,
+	"gb": GiByte,
+	"t":  TiByte,
+	"tb": TiByte,
+	"p":  PiByte,
+	"pb": PiByte,
+	"e":  EiByte,
+	"eb": EiByte,
+}
+
+var networkUnitValueTable = map[string]uint64{
+	"Bps":  Byte,
+	"Kbps": KByte / 8,
+	"KBps": KByte,
+	"Mbps": MByte / 8,
+	"MBps": MByte,
+	"Gbps": GByte / 8,
+	"GBps": GByte,
+	"Tbps": TByte / 8,
+	"TBps": TByte,
+	"Pbps": PByte / 8,
+	"PBps": PByte,
+	"Ebps": EByte / 8,
+	"EBps": EByte,
+}
+
+type rawBytes struct {
+	value     uint64
+	unit      string
+	unitValue uint64
+}
+
+func (b *rawBytes) Value() uint64 {
+	if b == nil {
+		return 0
+	}
+	return b.value
+}
+
+func (b rawBytes) MarshalJSON() ([]byte, error) {
+	if b.unit == "" {
+		return json.Marshal(b.value)
+	}
+	return json.Marshal(strconv.FormatUint(b.value/b.unitValue, 10) + b.unit)
+}
+
+func parseUnit(b *rawBytes, unitTable map[string]uint64, caseSensitive bool, bytes []byte) error {
+	var intValue int64
+	err := json.Unmarshal(bytes, &intValue)
+	if err == nil {
+		b.value = uint64(intValue)
+		b.unit = ""
+		b.unitValue = 1
+		return nil
+	}
+	var stringValue string
+	err = json.Unmarshal(bytes, &stringValue)
+	if err != nil {
+		return err
+	}
+	unitIndex := 0
+	for i, c := range stringValue {
+		if c < '0' || c > '9' {
+			unitIndex = i
+			break
+		}
+	}
+	if unitIndex == 0 {
+		return E.New("invalid format: ", stringValue)
+	}
+	value, err := strconv.ParseUint(stringValue[:unitIndex], 10, 64)
+	if err != nil {
+		return E.Cause(err, "parse ", stringValue[:unitIndex])
+	}
+	rawUnit := stringValue[unitIndex:]
+	var unit string
+	if caseSensitive {
+		unit = strings.TrimSpace(rawUnit)
+	} else {
+		unit = strings.TrimSpace(strings.ToLower(rawUnit))
+	}
+	unitValue, loaded := unitTable[unit]
+	if !loaded {
+		return E.New("unsupported unit: ", rawUnit)
+	}
+	b.value = value * unitValue
+	b.unit = rawUnit
+	b.unitValue = unitValue
+	return nil
+}
+
+type Bytes struct {
+	rawBytes
+}
+
+func (b *Bytes) UnmarshalJSON(bytes []byte) error {
+	return parseUnit(&b.rawBytes, unitValueTable, false, bytes)
+}
+
+type MemoryBytes struct {
+	rawBytes
+}
+
+func (m *MemoryBytes) UnmarshalJSON(bytes []byte) error {
+	return parseUnit(&m.rawBytes, memoryUnitValueTable, false, bytes)
+}
+
+type NetworkBytes struct {
+	rawBytes
+}
+
+func (n *NetworkBytes) UnmarshalJSON(bytes []byte) error {
+	return parseUnit(&n.rawBytes, networkUnitValueTable, true, bytes)
+}
+
+type NetworkBytesCompat struct {
+	rawBytes
+}
+
+func (n *NetworkBytesCompat) UnmarshalJSON(bytes []byte) error {
+	err := parseUnit(&n.rawBytes, networkUnitValueTable, true, bytes)
+	if err != nil {
+		newErr := parseUnit(&n.rawBytes, unitValueTable, false, bytes)
+		if newErr == nil {
+			return nil
+		}
+	}
+	return err
+}

--- a/common/byteformats/json_test.go
+++ b/common/byteformats/json_test.go
@@ -1,0 +1,114 @@
+package byteformats_test
+
+import (
+	"testing"
+
+	"github.com/sagernet/sing/common/byteformats"
+	"github.com/sagernet/sing/common/json"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestNetworkBytes(t *testing.T) {
+	t.Parallel()
+	testMap := map[string]uint64{
+		"1 Bps":  byteformats.Byte,
+		"1 Kbps": byteformats.KByte / 8,
+		"1 KBps": byteformats.KByte,
+		"1 Mbps": byteformats.MByte / 8,
+		"1 MBps": byteformats.MByte,
+		"1 Gbps": byteformats.GByte / 8,
+		"1 GBps": byteformats.GByte,
+		"1 Tbps": byteformats.TByte / 8,
+		"1 TBps": byteformats.TByte,
+		"1 Pbps": byteformats.PByte / 8,
+		"1 PBps": byteformats.PByte,
+		"1k":     byteformats.KByte,
+		"1m":     byteformats.MByte,
+	}
+	for k, v := range testMap {
+		var nb byteformats.NetworkBytesCompat
+		require.NoError(t, json.Unmarshal([]byte("\""+k+"\""), &nb))
+		require.Equal(t, v, nb.Value())
+		b, err := json.Marshal(nb)
+		require.NoError(t, err)
+		require.Equal(t, "\""+k+"\"", string(b))
+	}
+}
+
+func TestMemoryBytes(t *testing.T) {
+	t.Parallel()
+	testMap := map[string]uint64{
+		"1 B":  byteformats.Byte,
+		"1 KB": byteformats.KiByte,
+		"1 MB": byteformats.MiByte,
+		"1 GB": byteformats.GiByte,
+		"1 TB": byteformats.TiByte,
+		"1 PB": byteformats.PiByte,
+	}
+	for k, v := range testMap {
+		var mb byteformats.MemoryBytes
+		require.NoError(t, json.Unmarshal([]byte("\""+k+"\""), &mb))
+		require.Equal(t, v, mb.Value())
+		b, err := json.Marshal(mb)
+		require.NoError(t, err)
+		require.Equal(t, "\""+k+"\"", string(b))
+	}
+}
+
+func TestDefaultBytes(t *testing.T) {
+	t.Parallel()
+	testMap := map[string]uint64{
+		"1 B":   byteformats.Byte,
+		"1 KB":  byteformats.KByte,
+		"1 KiB": byteformats.KiByte,
+		"1 MB":  byteformats.MByte,
+		"1 MiB": byteformats.MiByte,
+		"1 GB":  byteformats.GByte,
+		"1 GiB": byteformats.GiByte,
+		"1 TB":  byteformats.TByte,
+		"1 TiB": byteformats.TiByte,
+		"1 PB":  byteformats.PByte,
+		"1 PiB": byteformats.PiByte,
+		"1 EB":  byteformats.EByte,
+		"1 EiB": byteformats.EiByte,
+		"1k":    byteformats.KByte,
+		"1m":    byteformats.MByte,
+		"1g":    byteformats.GByte,
+		"1t":    byteformats.TByte,
+		"1p":    byteformats.PByte,
+		"1e":    byteformats.EByte,
+		"1K":    byteformats.KByte,
+		"1M":    byteformats.MByte,
+		"1G":    byteformats.GByte,
+		"1T":    byteformats.TByte,
+		"1P":    byteformats.PByte,
+		"1E":    byteformats.EByte,
+		"1Ki":   byteformats.KiByte,
+		"1Mi":   byteformats.MiByte,
+		"1Gi":   byteformats.GiByte,
+		"1Ti":   byteformats.TiByte,
+		"1Pi":   byteformats.PiByte,
+		"1Ei":   byteformats.EiByte,
+		"1KiB":  byteformats.KiByte,
+		"1MiB":  byteformats.MiByte,
+		"1GiB":  byteformats.GiByte,
+		"1TiB":  byteformats.TiByte,
+		"1PiB":  byteformats.PiByte,
+		"1EiB":  byteformats.EiByte,
+		"1kB":   byteformats.KByte,
+		"1mB":   byteformats.MByte,
+		"1gB":   byteformats.GByte,
+		"1tB":   byteformats.TByte,
+		"1pB":   byteformats.PByte,
+		"1eB":   byteformats.EByte,
+	}
+	for k, v := range testMap {
+		var mb byteformats.Bytes
+		require.NoError(t, json.Unmarshal([]byte("\""+k+"\""), &mb))
+		require.Equal(t, v, mb.Value())
+		b, err := json.Marshal(mb)
+		require.NoError(t, err)
+		require.Equal(t, "\""+k+"\"", string(b))
+	}
+}

--- a/common/canceler/packet_wait.go
+++ b/common/canceler/packet_wait.go
@@ -1,0 +1,74 @@
+package canceler
+
+import (
+	"time"
+
+	"github.com/sagernet/sing/common/buf"
+	"github.com/sagernet/sing/common/bufio"
+	E "github.com/sagernet/sing/common/exceptions"
+	M "github.com/sagernet/sing/common/metadata"
+	N "github.com/sagernet/sing/common/network"
+)
+
+type timerPackerReadWaiter struct {
+	*TimerPacketConn
+	readWaiter N.PacketReadWaiter
+}
+
+func (c *TimerPacketConn) CreateReadWaiter() (N.PacketReadWaiter, bool) {
+	readWaiter, isReadWaiter := bufio.CreatePacketReadWaiter(c.PacketConn)
+	if !isReadWaiter {
+		return nil, false
+	}
+	return &timerPackerReadWaiter{c, readWaiter}, true
+}
+
+func (w *timerPackerReadWaiter) InitializeReadWaiter(options N.ReadWaitOptions) (needCopy bool) {
+	return w.readWaiter.InitializeReadWaiter(options)
+}
+
+func (w *timerPackerReadWaiter) WaitReadPacket() (buffer *buf.Buffer, destination M.Socksaddr, err error) {
+	buffer, destination, err = w.readWaiter.WaitReadPacket()
+	if err == nil {
+		w.instance.Update()
+	}
+	return
+}
+
+type timeoutPacketReadWaiter struct {
+	*TimeoutPacketConn
+	readWaiter N.PacketReadWaiter
+}
+
+func (c *TimeoutPacketConn) CreateReadWaiter() (N.PacketReadWaiter, bool) {
+	readWaiter, isReadWaiter := bufio.CreatePacketReadWaiter(c.PacketConn)
+	if !isReadWaiter {
+		return nil, false
+	}
+	return &timeoutPacketReadWaiter{c, readWaiter}, true
+}
+
+func (w *timeoutPacketReadWaiter) InitializeReadWaiter(options N.ReadWaitOptions) (needCopy bool) {
+	return w.readWaiter.InitializeReadWaiter(options)
+}
+
+func (w *timeoutPacketReadWaiter) WaitReadPacket() (buffer *buf.Buffer, destination M.Socksaddr, err error) {
+	for {
+		err = w.PacketConn.SetReadDeadline(time.Now().Add(w.timeout))
+		if err != nil {
+			return
+		}
+		buffer, destination, err = w.readWaiter.WaitReadPacket()
+		if err == nil {
+			w.active = time.Now()
+			return
+		} else if E.IsTimeout(err) {
+			if time.Since(w.active) > w.timeout {
+				w.cancel(err)
+				return
+			}
+		} else {
+			return
+		}
+	}
+}

--- a/common/control/bind_finder_default.go
+++ b/common/control/bind_finder_default.go
@@ -80,6 +80,13 @@ func (f *DefaultInterfaceFinder) ByIndex(index int) (*Interface, error) {
 func (f *DefaultInterfaceFinder) ByAddr(addr netip.Addr) (*Interface, error) {
 	for _, netInterface := range f.interfaces {
 		for _, prefix := range netInterface.Addresses {
+			if prefix.Addr() == addr {
+				return &netInterface, nil
+			}
+		}
+	}
+	for _, netInterface := range f.interfaces {
+		for _, prefix := range netInterface.Addresses {
 			if prefix.Contains(addr) {
 				return &netInterface, nil
 			}

--- a/common/domain/matcher_test.go
+++ b/common/domain/matcher_test.go
@@ -1,9 +1,6 @@
 package domain_test
 
 import (
-	"encoding/json"
-	"net/http"
-	"sort"
 	"testing"
 
 	"github.com/sagernet/sing/common/domain"
@@ -49,32 +46,4 @@ func TestMatcherLegacy(t *testing.T) {
 	dDomain, dDomainSuffix := matcher.Dump()
 	require.Equal(t, testDomain, dDomain)
 	require.Equal(t, testDomainSuffix, dDomainSuffix)
-}
-
-type simpleRuleSet struct {
-	Rules []struct {
-		Domain       []string `json:"domain"`
-		DomainSuffix []string `json:"domain_suffix"`
-	}
-}
-
-func TestDumpLarge(t *testing.T) {
-	t.Parallel()
-	response, err := http.Get("https://raw.githubusercontent.com/MetaCubeX/meta-rules-dat/sing/geo/geosite/cn.json")
-	require.NoError(t, err)
-	defer response.Body.Close()
-	var ruleSet simpleRuleSet
-	err = json.NewDecoder(response.Body).Decode(&ruleSet)
-	require.NoError(t, err)
-	domainList := ruleSet.Rules[0].Domain
-	domainSuffixList := ruleSet.Rules[0].DomainSuffix
-	require.Len(t, ruleSet.Rules, 1)
-	require.True(t, len(domainList)+len(domainSuffixList) > 0)
-	sort.Strings(domainList)
-	sort.Strings(domainSuffixList)
-	matcher := domain.NewMatcher(domainList, domainSuffixList, false)
-	require.NotNil(t, matcher)
-	dDomain, dDomainSuffix := matcher.Dump()
-	require.Equal(t, domainList, dDomain)
-	require.Equal(t, domainSuffixList, dDomainSuffix)
 }

--- a/common/exceptions/cause.go
+++ b/common/exceptions/cause.go
@@ -12,3 +12,16 @@ func (e *causeError) Error() string {
 func (e *causeError) Unwrap() error {
 	return e.cause
 }
+
+type causeError1 struct {
+	error
+	cause error
+}
+
+func (e *causeError1) Error() string {
+	return e.error.Error() + ": " + e.cause.Error()
+}
+
+func (e *causeError1) Unwrap() []error {
+	return []error{e.error, e.cause}
+}

--- a/common/exceptions/error.go
+++ b/common/exceptions/error.go
@@ -32,6 +32,13 @@ func Cause(cause error, message ...any) error {
 	return &causeError{F.ToString(message...), cause}
 }
 
+func Cause1(err error, cause error) error {
+	if cause == nil {
+		panic("cause on an nil error")
+	}
+	return &causeError1{err, cause}
+}
+
 func Extend(cause error, message ...any) error {
 	if cause == nil {
 		panic("extend on an nil error")

--- a/common/exceptions/multi.go
+++ b/common/exceptions/multi.go
@@ -13,7 +13,7 @@ type multiError struct {
 }
 
 func (e *multiError) Error() string {
-	return strings.Join(F.MapToString(e.errors), " | ")
+	return "(" + strings.Join(F.MapToString(e.errors), " | ") + ")"
 }
 
 func (e *multiError) Unwrap() []error {

--- a/common/json/badjson/merge_objects.go
+++ b/common/json/badjson/merge_objects.go
@@ -2,9 +2,11 @@ package badjson
 
 import (
 	"context"
+	"reflect"
 
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/json"
+	cJSON "github.com/sagernet/sing/common/json/internal/contextjson"
 )
 
 func MarshallObjects(objects ...any) ([]byte, error) {
@@ -31,16 +33,12 @@ func UnmarshallExcluded(inputContent []byte, parentObject any, object any) error
 }
 
 func UnmarshallExcludedContext(ctx context.Context, inputContent []byte, parentObject any, object any) error {
-	parentContent, err := newJSONObject(ctx, parentObject)
-	if err != nil {
-		return err
-	}
 	var content JSONObject
-	err = content.UnmarshalJSONContext(ctx, inputContent)
+	err := content.UnmarshalJSONContext(ctx, inputContent)
 	if err != nil {
 		return err
 	}
-	for _, key := range parentContent.Keys() {
+	for _, key := range cJSON.ObjectKeys(reflect.TypeOf(parentObject)) {
 		content.Remove(key)
 	}
 	if object == nil {

--- a/common/json/badoption/listable.go
+++ b/common/json/badoption/listable.go
@@ -3,11 +3,12 @@ package badoption
 import (
 	"context"
 
+	"github.com/sagernet/sing/common"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/json"
 )
 
-type Listable[T any] []T
+type Listable[T comparable] []T
 
 func (l Listable[T]) MarshalJSONContext(ctx context.Context) ([]byte, error) {
 	arrayList := []T(l)
@@ -18,13 +19,12 @@ func (l Listable[T]) MarshalJSONContext(ctx context.Context) ([]byte, error) {
 }
 
 func (l *Listable[T]) UnmarshalJSONContext(ctx context.Context, content []byte) error {
-	if string(content) == "null" {
-		return nil
-	}
 	var singleItem T
 	err := json.UnmarshalContextDisallowUnknownFields(ctx, content, &singleItem)
 	if err == nil {
-		*l = []T{singleItem}
+		if singleItem != common.DefaultValue[T]() {
+			*l = []T{singleItem}
+		}
 		return nil
 	}
 	newErr := json.UnmarshalContextDisallowUnknownFields(ctx, content, (*[]T)(l))

--- a/common/json/badoption/listable.go
+++ b/common/json/badoption/listable.go
@@ -3,12 +3,11 @@ package badoption
 import (
 	"context"
 
-	"github.com/sagernet/sing/common"
 	E "github.com/sagernet/sing/common/exceptions"
 	"github.com/sagernet/sing/common/json"
 )
 
-type Listable[T comparable] []T
+type Listable[T any] []T
 
 func (l Listable[T]) MarshalJSONContext(ctx context.Context) ([]byte, error) {
 	arrayList := []T(l)
@@ -19,11 +18,11 @@ func (l Listable[T]) MarshalJSONContext(ctx context.Context) ([]byte, error) {
 }
 
 func (l *Listable[T]) UnmarshalJSONContext(ctx context.Context, content []byte) error {
-	var singleItem T
+	var singleItem *T
 	err := json.UnmarshalContextDisallowUnknownFields(ctx, content, &singleItem)
 	if err == nil {
-		if singleItem != common.DefaultValue[T]() {
-			*l = []T{singleItem}
+		if singleItem != nil {
+			*l = []T{*singleItem}
 		}
 		return nil
 	}

--- a/common/json/internal/contextjson/keys.go
+++ b/common/json/internal/contextjson/keys.go
@@ -1,0 +1,20 @@
+package json
+
+import (
+	"reflect"
+
+	"github.com/sagernet/sing/common"
+)
+
+func ObjectKeys(object reflect.Type) []string {
+	switch object.Kind() {
+	case reflect.Pointer:
+		return ObjectKeys(object.Elem())
+	case reflect.Struct:
+	default:
+		panic("invalid non-struct input")
+	}
+	return common.Map(cachedTypeFields(object).list, func(field field) string {
+		return field.name
+	})
+}

--- a/common/json/internal/contextjson/keys_test.go
+++ b/common/json/internal/contextjson/keys_test.go
@@ -1,0 +1,26 @@
+package json_test
+
+import (
+	"reflect"
+	"testing"
+
+	json "github.com/sagernet/sing/common/json/internal/contextjson"
+
+	"github.com/stretchr/testify/require"
+)
+
+type MyObject struct {
+	Hello string `json:"hello,omitempty"`
+	MyWorld
+	MyWorld2 string `json:"-"`
+}
+
+type MyWorld struct {
+	World string `json:"world,omitempty"`
+}
+
+func TestObjectKeys(t *testing.T) {
+	t.Parallel()
+	keys := json.ObjectKeys(reflect.TypeOf(&MyObject{}))
+	require.Equal(t, []string{"hello", "world"}, keys)
+}

--- a/common/metadata/addr.go
+++ b/common/metadata/addr.go
@@ -42,7 +42,7 @@ func (ap Socksaddr) Unwrap() Socksaddr {
 }
 
 func (ap Socksaddr) IsFqdn() bool {
-	return IsDomainName(ap.Fqdn)
+	return isDomainName(ap.Fqdn)
 }
 
 func (ap Socksaddr) IsValid() bool {

--- a/common/metadata/domain.go
+++ b/common/metadata/domain.go
@@ -1,6 +1,71 @@
 package metadata
 
-import _ "unsafe" // for linkname
+// isDomainName checks if a string is a presentation-format domain name
+// (currently restricted to hostname-compatible "preferred name" LDH labels and
+// SRV-like "underscore labels"; see golang.org/issue/12421).
+//
+// isDomainName should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/sagernet/sing
+//
+// Do not remove or change the type signature.
+// See go.dev/issue/67401.
+func isDomainName(s string) bool {
+	// The root domain name is valid. See golang.org/issue/45715.
+	if s == "." {
+		return true
+	}
 
-//go:linkname IsDomainName net.isDomainName
-func IsDomainName(domain string) bool
+	// See RFC 1035, RFC 3696.
+	// Presentation format has dots before every label except the first, and the
+	// terminal empty label is optional here because we assume fully-qualified
+	// (absolute) input. We must therefore reserve space for the first and last
+	// labels' length octets in wire format, where they are necessary and the
+	// maximum total length is 255.
+	// So our _effective_ maximum is 253, but 254 is not rejected if the last
+	// character is a dot.
+	l := len(s)
+	if l == 0 || l > 254 || l == 254 && s[l-1] != '.' {
+		return false
+	}
+
+	last := byte('.')
+	nonNumeric := false // true once we've seen a letter or hyphen
+	partlen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_':
+			nonNumeric = true
+			partlen++
+		case '0' <= c && c <= '9':
+			// fine
+			partlen++
+		case c == '-':
+			// Byte before dash cannot be dot.
+			if last == '.' {
+				return false
+			}
+			partlen++
+			nonNumeric = true
+		case c == '.':
+			// Byte before dot cannot be dot, dash.
+			if last == '.' || last == '-' {
+				return false
+			}
+			if partlen > 63 || partlen == 0 {
+				return false
+			}
+			partlen = 0
+		}
+		last = c
+	}
+	if last == '-' || partlen > 63 {
+		return false
+	}
+
+	return nonNumeric
+}

--- a/common/udpnat2/conn.go
+++ b/common/udpnat2/conn.go
@@ -28,6 +28,7 @@ type natConn struct {
 	cache           freelru.Cache[netip.AddrPort, *natConn]
 	writer          N.PacketWriter
 	localAddr       M.Socksaddr
+	handlerAccess   sync.RWMutex
 	handler         N.UDPHandlerEx
 	packetChan      chan *N.PacketBuffer
 	closeOnce       sync.Once
@@ -75,23 +76,10 @@ func (c *natConn) WaitReadPacket() (buffer *buf.Buffer, destination M.Socksaddr,
 }
 
 func (c *natConn) SetHandler(handler N.UDPHandlerEx) {
-	select {
-	case <-c.doneChan:
-	default:
-	}
+	c.handlerAccess.Lock()
+	defer c.handlerAccess.Unlock()
 	c.handler = handler
 	c.readWaitOptions = N.NewReadWaitOptions(c.writer, handler)
-fetch:
-	for {
-		select {
-		case packet := <-c.packetChan:
-			c.handler.NewPacketEx(packet.Buffer, packet.Destination)
-			N.PutPacketBuffer(packet)
-			continue fetch
-		default:
-			break fetch
-		}
-	}
 }
 
 func (c *natConn) Timeout() time.Duration {

--- a/common/udpnat2/conn.go
+++ b/common/udpnat2/conn.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/sagernet/sing/common"
 	"github.com/sagernet/sing/common/buf"
 	"github.com/sagernet/sing/common/canceler"
 	M "github.com/sagernet/sing/common/metadata"
@@ -108,6 +109,7 @@ func (c *natConn) SetTimeout(timeout time.Duration) bool {
 func (c *natConn) Close() error {
 	c.closeOnce.Do(func() {
 		close(c.doneChan)
+		common.Close(c.handler)
 	})
 	return nil
 }

--- a/common/udpnat2/service.go
+++ b/common/udpnat2/service.go
@@ -74,8 +74,11 @@ func (s *Service) NewPacket(bufferSlices [][]byte, source M.Socksaddr, destinati
 	for _, bufferSlice := range bufferSlices {
 		buffer.Write(bufferSlice)
 	}
-	if conn.handler != nil {
-		conn.handler.NewPacketEx(buffer, destination)
+	conn.handlerAccess.RLock()
+	handler := conn.handler
+	conn.handlerAccess.RUnlock()
+	if handler != nil {
+		handler.NewPacketEx(buffer, destination)
 		return
 	}
 	packet := N.NewPacketBuffer()

--- a/service/pause/timer.go
+++ b/service/pause/timer.go
@@ -1,0 +1,24 @@
+package pause
+
+import (
+	"time"
+
+	"github.com/sagernet/sing/common/x/list"
+)
+
+func RegisterTicker(manager Manager, ticker *time.Ticker, duration time.Duration, resume func()) *list.Element[Callback] {
+	if manager.IsPaused() {
+		ticker.Stop()
+	}
+	return manager.RegisterCallback(func(event int) {
+		switch event {
+		case EventDevicePaused, EventNetworkPause:
+			ticker.Stop()
+		case EventDeviceWake, EventNetworkWake:
+			if resume != nil {
+				resume()
+			}
+			ticker.Reset(duration)
+		}
+	})
+}


### PR DESCRIPTION
I'm copy-pasting replacing the `net.isDomainName` linkname because this doesn't work on tinygo (main change is here: [09c5b07](https://github.com/getlantern/sing/pull/3/commits/09c5b07f682ff8caa66bf327066403b818d024d3)).

This pull request is also syncing the main branch with sagernet/sing repository