### PR TITLE
removing isDomainName linkname

### DIFF
--- a/common/metadata/addr.go
+++ b/common/metadata/addr.go
@@ -42,7 +42,7 @@ func (ap Socksaddr) Unwrap() Socksaddr {
 }
 
 func (ap Socksaddr) IsFqdn() bool {
-	return IsDomainName(ap.Fqdn)
+	return isDomainName(ap.Fqdn)
 }
 
 func (ap Socksaddr) IsValid() bool {

--- a/common/metadata/domain.go
+++ b/common/metadata/domain.go
@@ -1,6 +1,71 @@
 package metadata
 
-import _ "unsafe" // for linkname
+// isDomainName checks if a string is a presentation-format domain name
+// (currently restricted to hostname-compatible "preferred name" LDH labels and
+// SRV-like "underscore labels"; see golang.org/issue/12421).
+//
+// isDomainName should be an internal detail,
+// but widely used packages access it using linkname.
+// Notable members of the hall of shame include:
+//   - github.com/sagernet/sing
+//
+// Do not remove or change the type signature.
+// See go.dev/issue/67401.
+func isDomainName(s string) bool {
+	// The root domain name is valid. See golang.org/issue/45715.
+	if s == "." {
+		return true
+	}
 
-//go:linkname IsDomainName net.isDomainName
-func IsDomainName(domain string) bool
+	// See RFC 1035, RFC 3696.
+	// Presentation format has dots before every label except the first, and the
+	// terminal empty label is optional here because we assume fully-qualified
+	// (absolute) input. We must therefore reserve space for the first and last
+	// labels' length octets in wire format, where they are necessary and the
+	// maximum total length is 255.
+	// So our _effective_ maximum is 253, but 254 is not rejected if the last
+	// character is a dot.
+	l := len(s)
+	if l == 0 || l > 254 || l == 254 && s[l-1] != '.' {
+		return false
+	}
+
+	last := byte('.')
+	nonNumeric := false // true once we've seen a letter or hyphen
+	partlen := 0
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		default:
+			return false
+		case 'a' <= c && c <= 'z' || 'A' <= c && c <= 'Z' || c == '_':
+			nonNumeric = true
+			partlen++
+		case '0' <= c && c <= '9':
+			// fine
+			partlen++
+		case c == '-':
+			// Byte before dash cannot be dot.
+			if last == '.' {
+				return false
+			}
+			partlen++
+			nonNumeric = true
+		case c == '.':
+			// Byte before dot cannot be dot, dash.
+			if last == '.' || last == '-' {
+				return false
+			}
+			if partlen > 63 || partlen == 0 {
+				return false
+			}
+			partlen = 0
+		}
+		last = c
+	}
+	if last == '-' || partlen > 63 {
+		return false
+	}
+
+	return nonNumeric
+}


### PR DESCRIPTION
This pull request is part of getlantern/engineering#1762 
Tinygo isn't able to use the `linkname` replacement from sing and that would be a blocker for using the common package by the shadowsocks WATER implementation (which is not mandatory but help a lot by using `metadata.SocksAddr`), so this pull request is copy pasting the original [`isDomainName` from `net` package](https://cs.opensource.google/go/go/+/master:src/net/dnsclient.go;l=76-146;drc=05cbbf985fed823a174bf95cc78a7d44f948fdab) and removing `linkname`