### PR TITLE
Auto sync workflow

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -1,0 +1,28 @@
+name: Sync Fork with Upstream
+
+on:
+  schedule:
+    - cron: '0 0 * * 1' # Runs every Monday at 00:00 UTC
+
+  workflow_dispatch:
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Sync fork with upstream
+        uses: tgymnich/fork-sync@v2.0.10
+        with:
+          # The owner of your forked repository
+          owner: getlantern
+          # The name of your forked repository
+          repo: sing-box-minimal
+          # The branch in forked repository to update
+          head: lantern-main
+          # The branch in the *upstream* repository to sync with
+          base: main
+          merge_method: merge
+          auto_merge: false
+          pr_title: 'Automated Fork Sync from Upstream'
+          pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing-box`.'

--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -17,7 +17,7 @@ jobs:
           # The owner of your forked repository
           owner: getlantern
           # The name of your forked repository
-          repo: sing-box-minimal
+          repo: sing
           # The branch in forked repository to update
           head: lantern-main
           # The branch in the *upstream* repository to sync with
@@ -25,4 +25,4 @@ jobs:
           merge_method: merge
           auto_merge: false
           pr_title: 'Automated Fork Sync from Upstream'
-          pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing-box`.'
+          pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing`.'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # sing
 
-This branch is based off `main`.
-To keep in sync with `sagernet/sing`, first sync `main` and then merge `main` to this branch.
+The `lantern-main` branch is our primary working branch. It automatically syncs with `SagerNet/sing/main` on a weekly basis, but you can also trigger a manual sync by running the auto sync workflow.
+
+## 
 
 ![test](https://github.com/sagernet/sing/actions/workflows/test.yml/badge.svg)
 ![lint](https://github.com/sagernet/sing/actions/workflows/lint.yml/badge.svg)


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow to automate syncing `lantern-main` with `SagerNet/sing/main`. The workflow ensures that the fork remains up-to-date with the upstream changes on a weekly basis or when manually triggered.

### New GitHub Actions Workflow:

* [`.github/workflows/autosync.yml`](diffhunk://#diff-b86ac34ab277f841784a9f4716c422e7df86d47bdc35aff4821fec82424c56acR1-R28): Added a workflow named "Sync Fork with Upstream" that runs weekly on Mondays at 00:00 UTC or can be triggered manually. It uses the `tgymnich/fork-sync@v2.0.10` action to sync the `lantern-main` branch of the forked repository (`getlantern/sing`) with the `main` branch of the upstream repository (`sagernet/sing`).