### PR TITLE
swap head and base values in autosync

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -19,9 +19,9 @@ jobs:
           # The name of your forked repository
           repo: sing
           # The branch in forked repository to update
-          head: lantern-main
+          head: main
           # The branch in the *upstream* repository to sync with
-          base: main
+          base: lantern-main
           merge_method: merge
           auto_merge: false
           pr_title: 'Automated Fork Sync from Upstream'


### PR DESCRIPTION
This pull request includes a small but important update to the `.github/workflows/autosync.yml` file. The change swaps the `head` and `base` branch names in the workflow configuration to correct the synchronization direction between the forked and upstream repositories.

Changes to workflow configuration:

* [`.github/workflows/autosync.yml`](diffhunk://#diff-b86ac34ab277f841784a9f4716c422e7df86d47bdc35aff4821fec82424c56acL22-R24): Updated the `head` branch to `main` and the `base` branch to `lantern-main` to ensure the synchronization workflow properly reflects the intended branch structure.