### PR TITLE
automatically request pr reviewers

### DIFF
--- a/.github/workflows/autosync.yml
+++ b/.github/workflows/autosync.yml
@@ -12,17 +12,18 @@ jobs:
 
     steps:
       - name: Sync fork with upstream
-        uses: tgymnich/fork-sync@v2.0.10
+        uses: garmr-ulfr/fork-sync@request-pr-reviewers
         with:
           # The owner of your forked repository
           owner: getlantern
           # The name of your forked repository
           repo: sing
-          # The branch in forked repository to update
+          # The name of the branch where your changes are implemented.
           head: main
-          # The branch in the *upstream* repository to sync with
+          # The name of the branch you want the changes pulled into.
           base: lantern-main
           merge_method: merge
           auto_merge: false
           pr_title: 'Automated Fork Sync from Upstream'
           pr_message: 'This pull request was automatically generated to sync the `lantern-main` branch with the `main` branch from `sagernet/sing`.'
+          pr_reviewers: 'myleshorton,garmr-ulfr'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/autosync.yml` to enhance the fork synchronization process. The most notable changes include switching to a customized fork-sync action and adding reviewers to the automatically generated pull requests.

Updates to fork synchronization workflow:

* [`.github/workflows/autosync.yml`](diffhunk://#diff-b86ac34ab277f841784a9f4716c422e7df86d47bdc35aff4821fec82424c56acL15-R29): Added the `pr_reviewers` input to automatically assign reviewers (`myleshorton` and `garmr-ulfr`) to pull requests created during the fork synchronization process.