### PR TITLE
export IsDomain

### DIFF
--- a/common/metadata/addr.go
+++ b/common/metadata/addr.go
@@ -42,7 +42,7 @@ func (ap Socksaddr) Unwrap() Socksaddr {
 }
 
 func (ap Socksaddr) IsFqdn() bool {
-	return isDomainName(ap.Fqdn)
+	return IsDomainName(ap.Fqdn)
 }
 
 func (ap Socksaddr) IsValid() bool {

--- a/common/metadata/domain.go
+++ b/common/metadata/domain.go
@@ -1,17 +1,17 @@
 package metadata
 
-// isDomainName checks if a string is a presentation-format domain name
+// IsDomainName checks if a string is a presentation-format domain name
 // (currently restricted to hostname-compatible "preferred name" LDH labels and
 // SRV-like "underscore labels"; see golang.org/issue/12421).
 //
-// isDomainName should be an internal detail,
+// IsDomainName should be an internal detail,
 // but widely used packages access it using linkname.
 // Notable members of the hall of shame include:
 //   - github.com/sagernet/sing
 //
 // Do not remove or change the type signature.
 // See go.dev/issue/67401.
-func isDomainName(s string) bool {
+func IsDomainName(s string) bool {
 	// The root domain name is valid. See golang.org/issue/45715.
 	if s == "." {
 		return true


### PR DESCRIPTION
This PR exports `metadata.IsDomain`, which is used in sing-box (sing-box-minimal).